### PR TITLE
Config gitbook root directory

### DIFF
--- a/ko-KR/.gitbook.yaml
+++ b/ko-KR/.gitbook.yaml
@@ -1,0 +1,1 @@
+root: ./ko-KR


### PR DESCRIPTION
Config gitbook's root directory as ./ko-KR